### PR TITLE
fix: Add hyperlink to installer docs

### DIFF
--- a/installer.html
+++ b/installer.html
@@ -127,7 +127,9 @@
 
                     Follow the step in your terminal from there! Done!
 
-                    For more info please visit "https://github.com/ServNX/UNIT3D-INSTALLER"
+                    For more info please visit <a href="https://github.com/ServNX/UNIT3D-INSTALLER" target="_blank">
+                    https://github.com/ServNX/UNIT3D-INSTALLER
+                  </a>
                 </pre>
             </div>
 


### PR DESCRIPTION
This adds a link to the installer repository and opens in a new tab.